### PR TITLE
OpenTracing instrumentation for Neo4j RX driver

### DIFF
--- a/.mvn/wrapper/maven-wrapper.properties
+++ b/.mvn/wrapper/maven-wrapper.properties
@@ -1,1 +1,1 @@
-distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.5.3/apache-maven-3.5.3-bin.zip
+distributionUrl=https://repo1.maven.org/maven2/org/apache/maven/apache-maven/3.6.3/apache-maven-3.6.3-bin.zip

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
 
     <neo4j-java-driver.version>4.2.0</neo4j-java-driver.version>
     <testcontainers.version>1.15.1</testcontainers.version>
+    <reactor.version>3.4.2</reactor.version>
     <awaitility.version>4.0.0</awaitility.version>
     <junit.version>4.13.1</junit.version>
     <slf4j.version>1.7.30</slf4j.version>
@@ -136,6 +137,13 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-simple</artifactId>
       <version>${slf4j.version}</version>
+      <scope>test</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>io.projectreactor</groupId>
+      <artifactId>reactor-test</artifactId>
+      <version>${reactor.version}</version>
       <scope>test</scope>
     </dependency>
 

--- a/src/main/java/io/opentracing/contrib/neo4j/TracingAsyncSession.java
+++ b/src/main/java/io/opentracing/contrib/neo4j/TracingAsyncSession.java
@@ -156,7 +156,8 @@ public class TracingAsyncSession implements AsyncSession {
   @Override
   public CompletionStage<ResultCursor> runAsync(Query query, TransactionConfig config) {
     Span span = TracingHelper.build("runAsync", tracer);
-    span.setTag(Tags.DB_STATEMENT.getKey(), query.toString());
+    span.setTag(Tags.DB_STATEMENT.getKey(), query.text());
+    span.setTag("parameters", TracingHelper.mapToString(query.parameters().asMap()));
     span.setTag("config", config.toString());
     return decorate(session.runAsync(query, config), span);
   }
@@ -210,7 +211,8 @@ public class TracingAsyncSession implements AsyncSession {
   @Override
   public CompletionStage<ResultCursor> runAsync(Query query) {
     Span span = TracingHelper.build("run", tracer);
-    span.setTag(Tags.DB_STATEMENT.getKey(), query.toString());
+    span.setTag(Tags.DB_STATEMENT.getKey(), query.text());
+    span.setTag("parameters", TracingHelper.mapToString(query.parameters().asMap()));
     return decorate(session.runAsync(query), span);
   }
 }

--- a/src/main/java/io/opentracing/contrib/neo4j/TracingAsyncSession.java
+++ b/src/main/java/io/opentracing/contrib/neo4j/TracingAsyncSession.java
@@ -16,17 +16,14 @@ package io.opentracing.contrib.neo4j;
 import io.opentracing.Span;
 import io.opentracing.Tracer;
 import io.opentracing.tag.Tags;
-import java.util.Map;
-import java.util.concurrent.CompletionStage;
-import org.neo4j.driver.Bookmark;
-import org.neo4j.driver.Query;
-import org.neo4j.driver.Record;
-import org.neo4j.driver.TransactionConfig;
-import org.neo4j.driver.Value;
+import org.neo4j.driver.*;
 import org.neo4j.driver.async.AsyncSession;
 import org.neo4j.driver.async.AsyncTransaction;
 import org.neo4j.driver.async.AsyncTransactionWork;
 import org.neo4j.driver.async.ResultCursor;
+
+import java.util.Map;
+import java.util.concurrent.CompletionStage;
 
 import static io.opentracing.contrib.neo4j.TracingHelper.*;
 
@@ -42,14 +39,16 @@ public class TracingAsyncSession implements AsyncSession {
 
   @Override
   public CompletionStage<AsyncTransaction> beginTransactionAsync() {
-    // TODO
-    return session.beginTransactionAsync();
+    Span span = TracingHelper.build("transactionAsync", tracer);
+    CompletionStage<AsyncTransaction> transactionAsync = session.beginTransactionAsync();
+    return transactionAsync.thenApply(tr -> new TracingAsyncTransaction(tr, span, tracer));
   }
 
   @Override
   public CompletionStage<AsyncTransaction> beginTransactionAsync(TransactionConfig config) {
-    // TODO
-    return session.beginTransactionAsync(config);
+    Span span = TracingHelper.build("transactionAsync", tracer);
+    CompletionStage<AsyncTransaction> transactionAsync = session.beginTransactionAsync(config);
+    return transactionAsync.thenApply(tr -> new TracingAsyncTransaction(tr, span, tracer));
   }
 
   @Override

--- a/src/main/java/io/opentracing/contrib/neo4j/TracingAsyncTransaction.java
+++ b/src/main/java/io/opentracing/contrib/neo4j/TracingAsyncTransaction.java
@@ -110,7 +110,8 @@ public class TracingAsyncTransaction implements AsyncTransaction {
   @Override
   public CompletionStage<ResultCursor> runAsync(Query query) {
     Span span = TracingHelper.build("runAsync", parent, tracer);
-    span.setTag(Tags.DB_STATEMENT.getKey(), query.toString());
+    span.setTag(Tags.DB_STATEMENT.getKey(), query.text());
+    span.setTag("parameters", TracingHelper.mapToString(query.parameters().asMap()));
     return decorate(transaction.runAsync(query), span);
   }
 }

--- a/src/main/java/io/opentracing/contrib/neo4j/TracingAsyncTransaction.java
+++ b/src/main/java/io/opentracing/contrib/neo4j/TracingAsyncTransaction.java
@@ -31,17 +31,11 @@ public class TracingAsyncTransaction implements AsyncTransaction {
   private final AsyncTransaction transaction;
   private final Span parent;
   private final Tracer tracer;
-  private final boolean finishSpan;
 
   public TracingAsyncTransaction(AsyncTransaction transaction, Span parent, Tracer tracer) {
-    this(transaction, parent, tracer, false);
-  }
-
-  public TracingAsyncTransaction(AsyncTransaction transaction, Span parent, Tracer tracer, boolean finishSpan) {
     this.transaction = transaction;
     this.tracer = tracer;
     this.parent = parent;
-    this.finishSpan = finishSpan;
   }
 
   @Override

--- a/src/main/java/io/opentracing/contrib/neo4j/TracingDriver.java
+++ b/src/main/java/io/opentracing/contrib/neo4j/TracingDriver.java
@@ -14,7 +14,6 @@
 package io.opentracing.contrib.neo4j;
 
 import io.opentracing.Tracer;
-import java.util.concurrent.CompletionStage;
 import org.neo4j.driver.Driver;
 import org.neo4j.driver.Metrics;
 import org.neo4j.driver.Session;
@@ -22,6 +21,8 @@ import org.neo4j.driver.SessionConfig;
 import org.neo4j.driver.async.AsyncSession;
 import org.neo4j.driver.reactive.RxSession;
 import org.neo4j.driver.types.TypeSystem;
+
+import java.util.concurrent.CompletionStage;
 
 public class TracingDriver implements Driver {
 
@@ -50,14 +51,12 @@ public class TracingDriver implements Driver {
 
   @Override
   public RxSession rxSession() {
-    // TODO Missing Tracing Implementation
-    return driver.rxSession();
+    return new TracingRxSession(driver.rxSession(), tracer);
   }
 
   @Override
   public RxSession rxSession(SessionConfig sessionConfig) {
-    // TODO Missing Tracing Implementation
-    return driver.rxSession(sessionConfig);
+    return new TracingRxSession(driver.rxSession(sessionConfig), tracer);
   }
 
   @Override

--- a/src/main/java/io/opentracing/contrib/neo4j/TracingHelper.java
+++ b/src/main/java/io/opentracing/contrib/neo4j/TracingHelper.java
@@ -77,10 +77,6 @@ class TracingHelper {
     });
   }
 
-  static RxResult decorate(RxResult result, Span span) {
-    return new TracingRxResult(result, span);
-  }
-
   private static Map<String, Object> errorLogs(Throwable throwable) {
     Map<String, Object> errorLogs = new HashMap<>(2);
     errorLogs.put("event", Tags.ERROR.getKey());

--- a/src/main/java/io/opentracing/contrib/neo4j/TracingHelper.java
+++ b/src/main/java/io/opentracing/contrib/neo4j/TracingHelper.java
@@ -58,6 +58,10 @@ class TracingHelper {
     }
   }
 
+  static boolean isNotEmpty(Map<?, ?> map) {
+    return map != null && !map.isEmpty();
+  }
+
   static String mapToString(Map<String, Object> map) {
     if (map == null) {
       return "";

--- a/src/main/java/io/opentracing/contrib/neo4j/TracingRxResult.java
+++ b/src/main/java/io/opentracing/contrib/neo4j/TracingRxResult.java
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2018-2020 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.neo4j;
+
+import io.opentracing.Span;
+import org.neo4j.driver.Record;
+import org.neo4j.driver.internal.shaded.reactor.core.publisher.Flux;
+import org.neo4j.driver.reactive.RxResult;
+import org.neo4j.driver.summary.ResultSummary;
+import org.reactivestreams.Publisher;
+
+import java.util.List;
+
+import static io.opentracing.contrib.neo4j.TracingHelper.onError;
+
+public class TracingRxResult implements RxResult {
+  private final RxResult rxResult;
+  private final Span parent;
+
+  public TracingRxResult(RxResult rxResult, Span parent) {
+    this.rxResult = rxResult;
+    this.parent = parent;
+  }
+
+  @Override
+  public Publisher<List<String>> keys() {
+    return rxResult.keys();
+  }
+
+  @Override
+  public Publisher<Record> records() {
+    return Flux.from(rxResult.records())
+            .doOnComplete(parent::finish)
+            .doOnError(throwable -> {
+              onError(throwable, parent);
+              parent.finish();
+            });
+  }
+
+  @Override
+  public Publisher<ResultSummary> consume() {
+    return rxResult.consume();
+  }
+}

--- a/src/main/java/io/opentracing/contrib/neo4j/TracingRxSession.java
+++ b/src/main/java/io/opentracing/contrib/neo4j/TracingRxSession.java
@@ -49,6 +49,7 @@ public class TracingRxSession implements RxSession {
   @Override
   public Publisher<RxTransaction> beginTransaction(TransactionConfig transactionConfig) {
     Span span = TracingHelper.build("transactionRx", tracer);
+    span.setTag("config", transactionConfig.toString());
     Mono<RxTransaction> transaction = Mono.from(rxSession.beginTransaction(transactionConfig));
     return transaction.map(tr -> new TracingRxTransaction(tr, span, tracer));
   }

--- a/src/main/java/io/opentracing/contrib/neo4j/TracingRxSession.java
+++ b/src/main/java/io/opentracing/contrib/neo4j/TracingRxSession.java
@@ -117,7 +117,7 @@ public class TracingRxSession implements RxSession {
     span.setTag(Tags.DB_STATEMENT.getKey(), query);
     span.setTag("config", transactionConfig.toString());
 
-    return decorate(rxSession.run(query, transactionConfig), span);
+    return new TracingRxResult(rxSession.run(query, transactionConfig), span);
   }
 
   @Override
@@ -129,7 +129,7 @@ public class TracingRxSession implements RxSession {
       span.setTag("parameters", mapToString(parameters));
     }
 
-    return decorate(rxSession.run(query, parameters, transactionConfig), span);
+    return new TracingRxResult(rxSession.run(query, parameters, transactionConfig), span);
   }
 
   @Override
@@ -139,7 +139,7 @@ public class TracingRxSession implements RxSession {
     span.setTag("config", transactionConfig.toString());
     span.setTag("parameters", mapToString(query.parameters().asMap()));
 
-    return decorate(rxSession.run(query, transactionConfig), span);
+    return new TracingRxResult(rxSession.run(query, transactionConfig), span);
   }
 
   @Override
@@ -150,7 +150,7 @@ public class TracingRxSession implements RxSession {
       span.setTag("parameters", parameters.toString());
     }
 
-    return decorate(rxSession.run(query, parameters), span);
+    return new TracingRxResult(rxSession.run(query, parameters), span);
   }
 
   @Override
@@ -161,7 +161,7 @@ public class TracingRxSession implements RxSession {
       span.setTag("parameters", mapToString(parameters));
     }
 
-    return decorate(rxSession.run(query, parameters), span);
+    return new TracingRxResult(rxSession.run(query, parameters), span);
   }
 
   @Override
@@ -172,7 +172,7 @@ public class TracingRxSession implements RxSession {
       span.setTag("parameters", parameters.toString());
     }
 
-    return decorate(rxSession.run(query, parameters), span);
+    return new TracingRxResult(rxSession.run(query, parameters), span);
   }
 
   @Override
@@ -180,7 +180,7 @@ public class TracingRxSession implements RxSession {
     Span span = TracingHelper.build("runRx", tracer);
     span.setTag(Tags.DB_STATEMENT.getKey(), query);
 
-    return decorate(rxSession.run(query), span);
+    return new TracingRxResult(rxSession.run(query), span);
   }
 
   @Override
@@ -189,6 +189,6 @@ public class TracingRxSession implements RxSession {
     span.setTag(Tags.DB_STATEMENT.getKey(), query.text());
     span.setTag("parameters", mapToString(query.parameters().asMap()));
 
-    return decorate(rxSession.run(query), span);
+    return new TracingRxResult(rxSession.run(query), span);
   }
 }

--- a/src/main/java/io/opentracing/contrib/neo4j/TracingRxSession.java
+++ b/src/main/java/io/opentracing/contrib/neo4j/TracingRxSession.java
@@ -1,0 +1,194 @@
+/*
+ * Copyright 2018-2020 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.neo4j;
+
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import io.opentracing.tag.Tags;
+import org.neo4j.driver.*;
+import org.neo4j.driver.internal.shaded.reactor.core.publisher.Flux;
+import org.neo4j.driver.internal.shaded.reactor.core.publisher.Mono;
+import org.neo4j.driver.reactive.RxResult;
+import org.neo4j.driver.reactive.RxSession;
+import org.neo4j.driver.reactive.RxTransaction;
+import org.neo4j.driver.reactive.RxTransactionWork;
+import org.reactivestreams.Publisher;
+
+import java.util.Map;
+
+import static io.opentracing.contrib.neo4j.TracingHelper.*;
+
+public class TracingRxSession implements RxSession {
+
+  private final RxSession rxSession;
+  private final Tracer tracer;
+
+  public TracingRxSession(RxSession rxSession, Tracer tracer) {
+    this.rxSession = rxSession;
+    this.tracer = tracer;
+  }
+
+  @Override
+  public Publisher<RxTransaction> beginTransaction() {
+    Span span = TracingHelper.build("transactionRx", tracer);
+    Mono<RxTransaction> transaction = Mono.from(rxSession.beginTransaction());
+    return transaction.map(tr -> new TracingRxTransaction(tr, span, tracer));
+  }
+
+  @Override
+  public Publisher<RxTransaction> beginTransaction(TransactionConfig transactionConfig) {
+    Span span = TracingHelper.build("transactionRx", tracer);
+    Mono<RxTransaction> transaction = Mono.from(rxSession.beginTransaction(transactionConfig));
+    return transaction.map(tr -> new TracingRxTransaction(tr, span, tracer));
+  }
+
+  @Override
+  public <T> Publisher<T> readTransaction(RxTransactionWork<? extends Publisher<T>> rxTransactionWork) {
+    Span span = TracingHelper.build("readTransactionRx", tracer);
+
+    return Flux.from(rxSession.readTransaction(new TracingRxTransactionWork<>(rxTransactionWork, span, tracer)))
+            .doOnComplete(() -> span.finish())
+            .doOnError(throwable -> {
+              onError(throwable, span);
+              span.finish();
+            });
+  }
+
+  @Override
+  public <T> Publisher<T> readTransaction(RxTransactionWork<? extends Publisher<T>> rxTransactionWork, TransactionConfig transactionConfig) {
+    Span span = TracingHelper.build("readTransactionRx", tracer);
+
+    return Flux.from(rxSession.readTransaction(new TracingRxTransactionWork<>(rxTransactionWork, span, tracer), transactionConfig))
+            .doOnComplete(() -> span.finish())
+            .doOnError(throwable -> {
+              onError(throwable, span);
+              span.finish();
+            });
+  }
+
+  @Override
+  public <T> Publisher<T> writeTransaction(RxTransactionWork<? extends Publisher<T>> rxTransactionWork) {
+    Span span = TracingHelper.build("writeTransactionRx", tracer);
+
+    return Flux.from(rxSession.writeTransaction(new TracingRxTransactionWork<>(rxTransactionWork, span, tracer)))
+            .doOnComplete(() -> span.finish())
+            .doOnError(throwable -> {
+              onError(throwable, span);
+              span.finish();
+            });
+  }
+
+  @Override
+  public <T> Publisher<T> writeTransaction(RxTransactionWork<? extends Publisher<T>> rxTransactionWork, TransactionConfig transactionConfig) {
+    Span span = TracingHelper.build("writeTransactionRx", tracer);
+
+    return Flux.from(rxSession.writeTransaction(new TracingRxTransactionWork<>(rxTransactionWork, span, tracer), transactionConfig))
+            .doOnComplete(() -> span.finish())
+            .doOnError(throwable -> {
+              onError(throwable, span);
+              span.finish();
+            });
+  }
+
+  @Override
+  public Bookmark lastBookmark() {
+    return rxSession.lastBookmark();
+  }
+
+  @Override
+  public <T> Publisher<T> close() {
+    return rxSession.close();
+  }
+
+  @Override
+  public RxResult run(String query, TransactionConfig transactionConfig) {
+    Span span = TracingHelper.build("runRx", tracer);
+    span.setTag(Tags.DB_STATEMENT.getKey(), query);
+    span.setTag("config", transactionConfig.toString());
+
+    return decorate(rxSession.run(query, transactionConfig), span);
+  }
+
+  @Override
+  public RxResult run(String query, Map<String, Object> parameters, TransactionConfig transactionConfig) {
+    Span span = TracingHelper.build("runRx", tracer);
+    span.setTag(Tags.DB_STATEMENT.getKey(), query);
+    span.setTag("config", transactionConfig.toString());
+    if (parameters != null) {
+      span.setTag("parameters", mapToString(parameters));
+    }
+
+    return decorate(rxSession.run(query, parameters, transactionConfig), span);
+  }
+
+  @Override
+  public RxResult run(Query query, TransactionConfig transactionConfig) {
+    Span span = TracingHelper.build("runRx", tracer);
+    span.setTag(Tags.DB_STATEMENT.getKey(), query.text());
+    span.setTag("config", transactionConfig.toString());
+    span.setTag("parameters", mapToString(query.parameters().asMap()));
+
+    return decorate(rxSession.run(query, transactionConfig), span);
+  }
+
+  @Override
+  public RxResult run(String query, Value parameters) {
+    Span span = TracingHelper.build("runRx", tracer);
+    span.setTag(Tags.DB_STATEMENT.getKey(), query);
+    if (parameters != null) {
+      span.setTag("parameters", parameters.toString());
+    }
+
+    return decorate(rxSession.run(query, parameters), span);
+  }
+
+  @Override
+  public RxResult run(String query, Map<String, Object> parameters) {
+    Span span = TracingHelper.build("runRx", tracer);
+    span.setTag(Tags.DB_STATEMENT.getKey(), query);
+    if (parameters != null) {
+      span.setTag("parameters", mapToString(parameters));
+    }
+
+    return decorate(rxSession.run(query, parameters), span);
+  }
+
+  @Override
+  public RxResult run(String query, Record parameters) {
+    Span span = TracingHelper.build("runRx", tracer);
+    span.setTag(Tags.DB_STATEMENT.getKey(), query);
+    if (parameters != null) {
+      span.setTag("parameters", parameters.toString());
+    }
+
+    return decorate(rxSession.run(query, parameters), span);
+  }
+
+  @Override
+  public RxResult run(String query) {
+    Span span = TracingHelper.build("runRx", tracer);
+    span.setTag(Tags.DB_STATEMENT.getKey(), query);
+
+    return decorate(rxSession.run(query), span);
+  }
+
+  @Override
+  public RxResult run(Query query) {
+    Span span = TracingHelper.build("runRx", tracer);
+    span.setTag(Tags.DB_STATEMENT.getKey(), query.text());
+    span.setTag("parameters", mapToString(query.parameters().asMap()));
+
+    return decorate(rxSession.run(query), span);
+  }
+}

--- a/src/main/java/io/opentracing/contrib/neo4j/TracingRxTransaction.java
+++ b/src/main/java/io/opentracing/contrib/neo4j/TracingRxTransaction.java
@@ -73,7 +73,7 @@ public class TracingRxTransaction implements RxTransaction {
     Span span = TracingHelper.build("runRx", parent, tracer);
     span.setTag(Tags.DB_STATEMENT.getKey(), query);
     span.setTag("parameters", parameters.toString());
-    return decorate(transaction.run(query, parameters), span);
+    return new TracingRxResult(transaction.run(query, parameters), span);
   }
 
   @Override
@@ -83,7 +83,7 @@ public class TracingRxTransaction implements RxTransaction {
     if (parameters != null) {
       span.setTag("parameters", mapToString(parameters));
     }
-    return decorate(transaction.run(query, parameters), span);
+    return new TracingRxResult(transaction.run(query, parameters), span);
   }
 
   @Override
@@ -93,14 +93,14 @@ public class TracingRxTransaction implements RxTransaction {
     if (parameters != null) {
       span.setTag("parameters", mapToString(parameters.asMap()));
     }
-    return decorate(transaction.run(query, parameters), span);
+    return new TracingRxResult(transaction.run(query, parameters), span);
   }
 
   @Override
   public RxResult run(String query) {
     Span span = TracingHelper.build("runRx", parent, tracer);
     span.setTag(Tags.DB_STATEMENT.getKey(), query);
-    return decorate(transaction.run(query), span);
+    return new TracingRxResult(transaction.run(query), span);
   }
 
   @Override
@@ -108,6 +108,6 @@ public class TracingRxTransaction implements RxTransaction {
     Span span = TracingHelper.build("runRx", parent, tracer);
     span.setTag(Tags.DB_STATEMENT.getKey(), query.text());
     span.setTag("parameters", mapToString(query.parameters().asMap()));
-    return decorate(transaction.run(query), span);
+    return new TracingRxResult(transaction.run(query), span);
   }
 }

--- a/src/main/java/io/opentracing/contrib/neo4j/TracingRxTransaction.java
+++ b/src/main/java/io/opentracing/contrib/neo4j/TracingRxTransaction.java
@@ -33,17 +33,11 @@ public class TracingRxTransaction implements RxTransaction {
   private final RxTransaction transaction;
   private final Span parent;
   private final Tracer tracer;
-  private final boolean finishSpan;
 
   public TracingRxTransaction(RxTransaction transaction, Span parent, Tracer tracer) {
-    this(transaction, parent, tracer, false);
-  }
-
-  public TracingRxTransaction(RxTransaction transaction, Span parent, Tracer tracer, boolean finishSpan) {
     this.transaction = transaction;
     this.tracer = tracer;
     this.parent = parent;
-    this.finishSpan = finishSpan;
   }
 
   @Override

--- a/src/main/java/io/opentracing/contrib/neo4j/TracingRxTransaction.java
+++ b/src/main/java/io/opentracing/contrib/neo4j/TracingRxTransaction.java
@@ -1,0 +1,113 @@
+/*
+ * Copyright 2018-2020 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.neo4j;
+
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import io.opentracing.tag.Tags;
+import org.neo4j.driver.Query;
+import org.neo4j.driver.Record;
+import org.neo4j.driver.Value;
+import org.neo4j.driver.internal.shaded.reactor.core.publisher.Mono;
+import org.neo4j.driver.reactive.RxResult;
+import org.neo4j.driver.reactive.RxTransaction;
+import org.reactivestreams.Publisher;
+
+import java.util.Map;
+
+import static io.opentracing.contrib.neo4j.TracingHelper.*;
+
+public class TracingRxTransaction implements RxTransaction {
+
+  private final RxTransaction transaction;
+  private final Span parent;
+  private final Tracer tracer;
+  private final boolean finishSpan;
+
+  public TracingRxTransaction(RxTransaction transaction, Span parent,
+                              Tracer tracer) {
+    this(transaction, parent, tracer, false);
+  }
+
+  public TracingRxTransaction(RxTransaction transaction, Span parent, Tracer tracer,
+                              boolean finishSpan) {
+    this.transaction = transaction;
+    this.tracer = tracer;
+    this.parent = parent;
+    this.finishSpan = finishSpan;
+  }
+
+  @Override
+  public <T> Publisher<T> commit() {
+    return Mono.<T>from(transaction.commit())
+            .doOnSuccess(t -> parent.finish())
+            .doOnError(throwable -> {
+              onError(throwable, parent);
+              parent.finish();
+            });
+  }
+
+  @Override
+  public <T> Publisher<T> rollback() {
+    return Mono.<T>from(transaction.rollback())
+            .doOnSuccess(t -> parent.finish())
+            .doOnError(throwable -> {
+              onError(throwable, parent);
+              parent.finish();
+            });
+  }
+
+  @Override
+  public RxResult run(String query, Value parameters) {
+    Span span = TracingHelper.build("runRx", parent, tracer);
+    span.setTag(Tags.DB_STATEMENT.getKey(), query);
+    span.setTag("parameters", parameters.toString());
+    return decorate(transaction.run(query, parameters), span);
+  }
+
+  @Override
+  public RxResult run(String query, Map<String, Object> parameters) {
+    Span span = TracingHelper.build("runRx", parent, tracer);
+    span.setTag(Tags.DB_STATEMENT.getKey(), query);
+    if (parameters != null) {
+      span.setTag("parameters", mapToString(parameters));
+    }
+    return decorate(transaction.run(query, parameters), span);
+  }
+
+  @Override
+  public RxResult run(String query, Record parameters) {
+    Span span = TracingHelper.build("runRx", parent, tracer);
+    span.setTag(Tags.DB_STATEMENT.getKey(), query);
+    if (parameters != null) {
+      span.setTag("parameters", mapToString(parameters.asMap()));
+    }
+    return decorate(transaction.run(query, parameters), span);
+  }
+
+  @Override
+  public RxResult run(String query) {
+    Span span = TracingHelper.build("runRx", parent, tracer);
+    span.setTag(Tags.DB_STATEMENT.getKey(), query);
+    return decorate(transaction.run(query), span);
+  }
+
+  @Override
+  public RxResult run(Query query) {
+    Span span = TracingHelper.build("runRx", parent, tracer);
+    span.setTag(Tags.DB_STATEMENT.getKey(), query.text());
+    span.setTag("parameters", mapToString(query.parameters().asMap()));
+    return decorate(transaction.run(query), span);
+  }
+}

--- a/src/main/java/io/opentracing/contrib/neo4j/TracingRxTransactionWork.java
+++ b/src/main/java/io/opentracing/contrib/neo4j/TracingRxTransactionWork.java
@@ -1,0 +1,46 @@
+/*
+ * Copyright 2018-2020 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.neo4j;
+
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import org.neo4j.driver.reactive.RxTransaction;
+import org.neo4j.driver.reactive.RxTransactionWork;
+
+public class TracingRxTransactionWork<T> implements RxTransactionWork<T> {
+
+  private final Tracer tracer;
+
+  private final Span parent;
+
+  private final RxTransactionWork<T> transactionWork;
+
+  public TracingRxTransactionWork(RxTransactionWork<T> transactionWork, Span parent,
+                                  Tracer tracer) {
+    this.transactionWork = transactionWork;
+    this.tracer = tracer;
+    this.parent = parent;
+  }
+
+  @Override
+  public T execute(RxTransaction tx) {
+    try {
+      parent.log("execute");
+      return transactionWork.execute(new TracingRxTransaction(tx, parent, tracer));
+    } catch (Exception e) {
+      TracingHelper.onError(e, parent);
+      throw e;
+    }
+  }
+}

--- a/src/main/java/io/opentracing/contrib/neo4j/TracingSession.java
+++ b/src/main/java/io/opentracing/contrib/neo4j/TracingSession.java
@@ -105,7 +105,8 @@ public class TracingSession implements Session {
   @Override
   public Result run(Query query, TransactionConfig config) {
     Span span = TracingHelper.build("run", tracer);
-    span.setTag(Tags.DB_STATEMENT.getKey(), query.toString());
+    span.setTag(Tags.DB_STATEMENT.getKey(), query.text());
+    span.setTag("parameters", TracingHelper.mapToString(query.parameters().asMap()));
     span.setTag("config", config.toString());
     return decorate(() -> session.run(query, config), span, tracer);
   }
@@ -175,7 +176,8 @@ public class TracingSession implements Session {
   @Override
   public Result run(Query query) {
     Span span = TracingHelper.build("run", tracer);
-    span.setTag(Tags.DB_STATEMENT.getKey(), query.toString());
+    span.setTag(Tags.DB_STATEMENT.getKey(), query.text());
+    span.setTag("parameters", TracingHelper.mapToString(query.parameters().asMap()));
     return decorate(() -> session.run(query), span, tracer);
   }
 }

--- a/src/main/java/io/opentracing/contrib/neo4j/TracingTransaction.java
+++ b/src/main/java/io/opentracing/contrib/neo4j/TracingTransaction.java
@@ -118,7 +118,8 @@ public class TracingTransaction implements Transaction {
   @Override
   public Result run(Query query) {
     Span span = TracingHelper.build("run", parent, tracer);
-    span.setTag(Tags.DB_STATEMENT.getKey(), query.toString());
+    span.setTag(Tags.DB_STATEMENT.getKey(), query.text());
+    span.setTag("parameters", TracingHelper.mapToString(query.parameters().asMap()));
     return decorate(() -> transaction.run(query), span, tracer);
   }
 }

--- a/src/main/java/io/opentracing/contrib/neo4j/TracingTransaction.java
+++ b/src/main/java/io/opentracing/contrib/neo4j/TracingTransaction.java
@@ -13,18 +13,19 @@
  */
 package io.opentracing.contrib.neo4j;
 
-import static io.opentracing.contrib.neo4j.TracingHelper.decorate;
-import static io.opentracing.contrib.neo4j.TracingHelper.mapToString;
-
 import io.opentracing.Span;
 import io.opentracing.Tracer;
 import io.opentracing.tag.Tags;
+
 import java.util.Map;
+
 import org.neo4j.driver.Query;
 import org.neo4j.driver.Record;
 import org.neo4j.driver.Result;
 import org.neo4j.driver.Transaction;
 import org.neo4j.driver.Value;
+
+import static io.opentracing.contrib.neo4j.TracingHelper.*;
 
 public class TracingTransaction implements Transaction {
 
@@ -33,15 +34,11 @@ public class TracingTransaction implements Transaction {
   private final Tracer tracer;
   private final boolean finishSpan;
 
-  public TracingTransaction(
-      Transaction transaction, Span parent,
-      Tracer tracer) {
+  public TracingTransaction(Transaction transaction, Span parent, Tracer tracer) {
     this(transaction, parent, tracer, false);
   }
 
-  public TracingTransaction(
-      Transaction transaction, Span parent, Tracer tracer,
-      boolean finishSpan) {
+  public TracingTransaction(Transaction transaction, Span parent, Tracer tracer, boolean finishSpan) {
     this.transaction = transaction;
     this.tracer = tracer;
     this.parent = parent;
@@ -77,33 +74,33 @@ public class TracingTransaction implements Transaction {
   }
 
   @Override
-  public Result run(String statementTemplate, Value parameters) {
+  public Result run(String statementTemplate, Value parametersValue) {
     Span span = TracingHelper.build("run", parent, tracer);
     span.setTag(Tags.DB_STATEMENT.getKey(), statementTemplate);
-    span.setTag("parameters", parameters.toString());
+    Map<String, Object> parameters = parametersValue.asMap();
+    if (isNotEmpty(parameters)) {
+      span.setTag("parameters", mapToString(parameters));
+    }
     return decorate(() -> transaction.run(statementTemplate, parameters), span, tracer);
   }
 
   @Override
-  public Result run(
-      String statementTemplate,
-      Map<String, Object> statementParameters) {
+  public Result run(String statementTemplate, Map<String, Object> parameters) {
     Span span = TracingHelper.build("run", parent, tracer);
     span.setTag(Tags.DB_STATEMENT.getKey(), statementTemplate);
-    if (statementParameters != null) {
-      span.setTag("parameters", mapToString(statementParameters));
+    if (isNotEmpty(parameters)) {
+      span.setTag("parameters", mapToString(parameters));
     }
-    return decorate(() -> transaction.run(statementTemplate, statementParameters), span, tracer);
+    return decorate(() -> transaction.run(statementTemplate, parameters), span, tracer);
   }
 
   @Override
-  public Result run(
-      String statementTemplate,
-      Record statementParameters) {
+  public Result run(String statementTemplate, Record statementParameters) {
     Span span = TracingHelper.build("run", parent, tracer);
     span.setTag(Tags.DB_STATEMENT.getKey(), statementTemplate);
-    if (statementParameters != null) {
-      span.setTag("parameters", mapToString(statementParameters.asMap()));
+    Map<String, Object> parameters = statementParameters.asMap();
+    if (isNotEmpty(parameters)) {
+      span.setTag("parameters", mapToString(parameters));
     }
     return decorate(() -> transaction.run(statementTemplate, statementParameters), span, tracer);
   }
@@ -119,7 +116,10 @@ public class TracingTransaction implements Transaction {
   public Result run(Query query) {
     Span span = TracingHelper.build("run", parent, tracer);
     span.setTag(Tags.DB_STATEMENT.getKey(), query.text());
-    span.setTag("parameters", TracingHelper.mapToString(query.parameters().asMap()));
+    Map<String, Object> parameters = query.parameters().asMap();
+    if (isNotEmpty(parameters)) {
+      span.setTag("parameters", mapToString(parameters));
+    }
     return decorate(() -> transaction.run(query), span, tracer);
   }
 }

--- a/src/test/java/io/opentracing/contrib/neo4j/TracingHelperTest.java
+++ b/src/test/java/io/opentracing/contrib/neo4j/TracingHelperTest.java
@@ -1,0 +1,32 @@
+/*
+ * Copyright 2018-2020 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.neo4j;
+
+import org.junit.Test;
+
+import java.util.Collections;
+
+import static io.opentracing.contrib.neo4j.TracingHelper.isNotEmpty;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+public class TracingHelperTest {
+
+  @Test
+  public void testIsNotEmpty() {
+    assertTrue(isNotEmpty(Collections.singletonMap("key", "value")));
+    assertFalse(isNotEmpty(Collections.emptyMap()));
+    assertFalse(isNotEmpty(null));
+  }
+}

--- a/src/test/java/io/opentracing/contrib/neo4j/TracingTest.java
+++ b/src/test/java/io/opentracing/contrib/neo4j/TracingTest.java
@@ -22,7 +22,6 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.neo4j.driver.*;
 import org.testcontainers.containers.Neo4jContainer;
-import org.testcontainers.utility.DockerImageName;
 
 import java.util.List;
 


### PR DESCRIPTION
This PR adds OpenTracing logging support for the reactive Neo4j driver. 
I've tried to use the same approach as for Async version, including testing.